### PR TITLE
Don't return `res`, which may be unset

### DIFF
--- a/txrequests/sessions.py
+++ b/txrequests/sessions.py
@@ -63,8 +63,7 @@ class Session(requestsSession):
                 reactor.callFromThread(d.callback, res)
             except Exception as e:
                 reactor.callFromThread(d.errback, e)
-            return res
-
+ 
         d = defer.Deferred()
         self.pool.callInThread(func)
         return d


### PR DESCRIPTION
The return value of `func` is ignored anyway, but if there is an exception then it will not be set.
