### PR TITLE
Stop pool only after shutdown

### DIFF
--- a/txrequests/sessions.py
+++ b/txrequests/sessions.py
@@ -43,7 +43,7 @@ class Session(requestsSession):
             pool = ThreadPool(minthreads=minthreads, maxthreads=maxthreads)
             # unclosed ThreadPool leads to reactor hangs at shutdown
             # this is a problem in many situation, so better enforce pool stop here
-            reactor.addSystemEventTrigger("before", "shutdown", lambda:pool.stop())
+            reactor.addSystemEventTrigger("after", "shutdown", lambda:pool.stop())
         self.pool = pool
         if self.ownPool:
             pool.start()


### PR DESCRIPTION
People often add their cleanup code via `addSystemTrigger('before', 'shutdown', callback)`. Sometimes this cleanup code contains additional requests. We should therefore only close the thread pool at a later stage.

Thanks for this package :)