### PR TITLE
Fix small typo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ for a simple example take json parsing.
     from txrequests import Session
 
     @defer.inlineCallbacks
-    def main()
+    def main():
         with Session() as session:
 
             def bg_cb(sess, resp):


### PR DESCRIPTION
Fix missing colon in function heading of main()